### PR TITLE
updated react-template version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/wix/grunt-react-templates",
   "dependencies": {
-    "react-templates": "0.3.2"
+    "react-templates": "0.4.3"
   },
   "keywords": [
     "templates",


### PR DESCRIPTION
Can we update the react-template version? This library is still using the version that causes lodash errors for things like rt-class.
